### PR TITLE
add ability to specify via PROJ.4

### DIFF
--- a/fio_area/__init__.py
+++ b/fio_area/__init__.py
@@ -53,7 +53,7 @@ def addArea(feature, calc_crs):
     elif calc_crs is None:
         {'init': getZone(findExtrema(feature))}
     else:
-        eCode = {'init': calc_crs}
+        ecode = {'init': calc_crs}
 
     area = projectShapes(feature, ecode).area
 


### PR DESCRIPTION
EG
```
fio area --calc-crs "+proj=moll +lon_0=0 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs"
```
cc @camillacaros 