### PR TITLE
densifying features

### DIFF
--- a/fio_area/scripts/cli.py
+++ b/fio_area/scripts/cli.py
@@ -18,14 +18,14 @@ from fio_area.utils import _area_adder, _poly_filter
     default="esri:54009",
     help="Projection to calculate area in [DEFAULT=esri:54009]",
 )
+@click.option("--densify", type=int, default=None,
+    help="Densify between feature vertices before projecting; helps with accuracy for sparse globe-spanning geometries")
 @click.pass_context
 @cligj.features_in_arg
 @cligj.sequence_opt
-def area(ctx, features, summary, calc_crs, sequence):
+def area(ctx, features, summary, calc_crs, densify, sequence):
     features = _poly_filter(features)
-
-    calc_crs = calc_crs.lower()
-    features, sums = zip(*[[f, a] for f, a in _area_adder(features, calc_crs)])
+    features, sums = zip(*[[f, a] for f, a in _area_adder(features, calc_crs, densify=densify)])
 
     if summary:
         stats = [np.min, np.max, np.mean, np.sum, np.std]

--- a/fio_area/utils.py
+++ b/fio_area/utils.py
@@ -7,7 +7,6 @@ import fiona.crs as fcrs
 from shapely.geometry import shape
 from shapely.ops import transform as shpTrans
 
-
 def getZone(bbox, zonethresh=3):
     minZone = int((bbox[0] + 180) // 6.0)
     ctrZone = int((((bbox[2] - bbox[0]) / 2.0 + bbox[0]) + 180) // 6.0)
@@ -23,11 +22,33 @@ def getZone(bbox, zonethresh=3):
     else:
         return "epsg:{0}{1}".format(zmap[is_n], ctrZone)
 
+def densify_segment(start, end, densify=10):
+    x_a, y_a = start
+    x_b, y_b = end
 
-def projectShapes(feature, toCRS):
+    x = np.linspace(x_a, x_b - (x_b - x_a) / densify, densify)
+    y = np.linspace(y_a, y_b - (y_b - y_a) / densify, densify)
+
+    for xy in zip(x, y):
+        yield xy
+
+
+
+def densify_geometry(geometry, densify=10):
+    """Simply interval densification"""
+    if geometry["type"] == "Polygon":
+
+        for idx, part in enumerate(geometry["coordinates"]):
+            geometry["coordinates"][idx] = [c for a, b in zip(part[:-1], part[1:]) for c in densify_segment(a, b, densify=densify)]
+
+        return geometry
+def projectShapes(feature, toCRS, densify=None):
     project = partial(
-        pyproj.transform, pyproj.Proj(fcrs.from_epsg(4326)), pyproj.Proj(toCRS)
-    )
+        pyproj.transform, pyproj.Proj(fcrs.from_epsg(4326)), pyproj.Proj(toCRS))
+
+    if densify is not None:
+        print(densify)
+        feature["geometry"] = densify_geometry(feature["geometry"], densify)
 
     return shpTrans(project, shape(feature["geometry"]))
 
@@ -45,20 +66,20 @@ def findExtrema(features):
     return [xMin, yMin, xMax, yMax]
 
 
-def addArea(feature, calc_crs):
+def addArea(feature, calc_crs, densify=10):
+
     if calc_crs is None:
         eCode = getZone(findExtrema(feature))
     else:
         eCode = calc_crs
-
-    area = projectShapes(feature, {"init": eCode}).area
+    area = projectShapes(feature, eCode, densify=densify).area
 
     return area
 
 
-def _area_adder(features, calc_crs):
+def _area_adder(features, calc_crs, densify=10):
     for f in features:
-        areacalc = addArea(f, calc_crs)
+        areacalc = addArea(f, calc_crs, densify=densify)
         f["properties"]["area"] = areacalc
         yield f, areacalc
 


### PR DESCRIPTION
Adds a densification option for global, sparse data
```
$ echo '[0, 0, 0]' | mercantile shapes | fio area -s
{"min": 130869699320433.84, "max": 130869699320433.84, "mean": 130869699320433.84, "sum": 130869699320433.84, "std": 0.0}
$ fio-area git:(denser-features) ✗ echo '[0, 0, 0]' | mercantile shapes | fio area -s --densify 10
{"min": 503318344705311.06, "max": 503318344705311.06, "mean": 503318344705311.06, "sum": 503318344705311.06, "std": 0.0}