### PR TITLE
Invalid proj

### DIFF
--- a/fio_area/utils.py
+++ b/fio_area/utils.py
@@ -51,7 +51,7 @@ def addArea(feature, calc_crs):
     else:
         eCode = calc_crs
 
-    area = projectShapes(feature, {"init": eCode}).area
+    area = projectShapes(feature, eCode).area
 
     return area
 

--- a/fio_area/utils.py
+++ b/fio_area/utils.py
@@ -65,7 +65,8 @@ def _area_adder(features, calc_crs):
 
 def _poly_filter(features):
     for f in features:
-        if f["geometry"]["type"] == "MultiPolygon" or f["geometry"][
-            "type"
-        ] == "Polygon":
+        if (
+            f["geometry"]["type"] == "MultiPolygon"
+            or f["geometry"]["type"] == "Polygon"
+        ):
             yield f

--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,11 @@ from codecs import open as codecs_open
 from setuptools import setup, find_packages
 
 
-with codecs_open('README.rst', encoding='utf-8') as f:
+with codecs_open("README.rst", encoding="utf-8") as f:
     long_description = f.read()
 
 # Parse the version from the pxmcli module.
-with open('fio_area/__init__.py') as f:
+with open("fio_area/__init__.py") as f:
     for line in f:
         if line.find("__version__") >= 0:
             version = line.split("=")[1].strip()
@@ -15,32 +15,30 @@ with open('fio_area/__init__.py') as f:
             continue
 
 
-inst_reqs = [
-    'click', 'cligj', 'Fiona', 'numpy', 'pyproj', 'Shapely'
-]
+inst_reqs = ["click", "cligj", "Fiona", "numpy", "pyproj", "Shapely"]
 
-setup(name='fio-area',
-      version=version,
-      description="Fiona CLI plugin to calculate areas",
-      long_description=long_description,
-      classifiers=[
-          'Topic :: Scientific/Engineering :: GIS',
-          'Programming Language :: Python :: 2.7',
-          'Programming Language :: Python :: 3.6'
-      ],
-      keywords='fiona',
-      author=u"Damon Burgett",
-      author_email='damon@mapbox.com',
-      url='https://github.com/mapbox/fio-area',
-      license='BSD',
-      packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
-      include_package_data=True,
-      zip_safe=False,
-      install_requires=inst_reqs,
-      extras_require={
-          'test': ['pytest', 'pytest-cov'],
-      },
-      entry_points="""
+setup(
+    name="fio-area",
+    version=version,
+    description="Fiona CLI plugin to calculate areas",
+    long_description=long_description,
+    classifiers=[
+        "Topic :: Scientific/Engineering :: GIS",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.6",
+    ],
+    keywords="fiona",
+    author=u"Damon Burgett",
+    author_email="damon@mapbox.com",
+    url="https://github.com/mapbox/fio-area",
+    license="BSD",
+    packages=find_packages(exclude=["ez_setup", "examples", "tests"]),
+    include_package_data=True,
+    zip_safe=False,
+    install_requires=inst_reqs,
+    extras_require={"test": ["pytest", "pytest-cov"]},
+    entry_points="""
       [fiona.fio_commands]
       area=fio_area.scripts.cli:area
-      """)
+      """,
+)


### PR DESCRIPTION
pyproj.exceptions.CRSError: Invalid projection with default crs. Probably the result of pyproj (or proj 🤷 ) changes.  The fix is to pass pyproj a string that is the esri or epsg string (ie "esri:54009" or 'EPSG:32631') instead of a dict containing that string.
functional change is [8ab2979](https://github.com/mapbox/fio-area/commit/8ab2979f3e68749e8ad046b369da0f578705462e)
The other commit is just pre-commit automated formatting changes.